### PR TITLE
adicionando Ruby4noobs a lista de 4noobs

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -25,4 +25,4 @@ Segue a lista dos repositórios
 | ux4Noobs - Introdução ao UX | 7K | [ux4noobs](https://github.com/IUX7K/ux4noobs/) |
 | c4noobs - Introdução ao C | João Paulo, Paulo Rievrs | [c4noobs](https://github.com/jpaulohe4rt/c4noobs/) |
 | vim4noobs - Introdução ao Vim :wq | hellowluan | [vim4noobs](https://github.com/hellowluan/vim4noobs) |
-
+| ruby4noobs - Introdução ao Ruby | Ederson Ferreira | [ruby4noobs](https://github.com/edersonferreira/ruby4noobs)


### PR DESCRIPTION
Criei um repositório de 4noobs de Ruby, que está em [edersonferreira/ruby4noobs](https://github.com/edersonferreira/ruby4noobs), e neste Pull Request, **coloco o Ruby4Noobs na tabela dos 4noobs no README.md.**
Um Abraço.