### PR TITLE
Adicionando Rails4Noobs

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -26,5 +26,6 @@ Segue a lista dos repositórios
 | c4noobs - Introdução ao C | João Paulo, Paulo Rievrs | [c4noobs](https://github.com/jpaulohe4rt/c4noobs/) |
 | vim4noobs - Introdução ao Vim :wq | hellowluan | [vim4noobs](https://github.com/hellowluan/vim4noobs) |
 | ruby4noobs - Introdução ao Ruby | Ederson Ferreira | [ruby4noobs](https://github.com/edersonferreira/ruby4noobs) |
+| rails4noobs - Introdução ao Ruby on Rails | Ederson Ferreira | [rails4noobs](https://github.com/edersonferreira/rails4noobs) |
 | NextJs4noobs - Introdução ao NextJs | gaviusking | [NextJs4noobs](https://github.com/gaviusking/NextJs4noobs) |
 | Markdown4Noobs - Introdução ao Markdown | jpaulohe4rt, dsm, freazesss e EduardoFerro | [Markdown4Noobs](https://github.com/jpaulohe4rt/markdown4noobs) |


### PR DESCRIPTION
Neste pull request, adiciono o repositório [edersonferreira/rails4noobs](https://github.com/edersonferreira/rails4noobs) na lista de 4noobs abaixo de ruby4noobs, pois acho interessante que um esteja próximo ao outro, mas o responsável que está lendo esta pull request, pode mudar a posição do Rails4noobs á sua escolha.