### PR TITLE
fix: Flutter4Noobs username no arquivo `config.json`

### DIFF
--- a/.github/config.json
+++ b/.github/config.json
@@ -300,10 +300,10 @@
       "category": "Frameworks",
       "author": {
         "name": "Felipe Ribeiro",
-        "username": "feliper2002",
-        "avatar_url": "https://github.com/feliper2002.png"
+        "username": "feliperfdev",
+        "avatar_url": "https://github.com/feliperfdev.png"
       },
-      "url": "https://github.com/feliper2002/flutter4noobs"
+      "url": "https://github.com/feliperfdev/flutter4noobs"
     },
     {
       "name": "Django4noobs",


### PR DESCRIPTION
Corrigindo username do Flutter4Noobs no arquivo `config.json` para ajustar exibição na landing page da He4rt.

O usuário do autor do repositório havia sido mudado, mas não foi corrigido no arquivo `config.json`, apenas no README. Este PR corrige esse username no `config.json` para que agora fique tudo certo.