### PR TITLE
feat: add automation frameworks section with multiple tools

### DIFF
--- a/.github/config.json
+++ b/.github/config.json
@@ -613,13 +613,76 @@
       "tags": ["Testes", "Automação"],
       "image": "https://cdn.jsdelivr.net/gh/devicons/devicon/icons/selenium/selenium-original.svg",
       "description": "Aprenda a usar o Selenium para automação de testes web.",
-      "category": "Ferramentas",
+      "category": "Frameworks de Automação",
       "author": {
         "name": "João Pedro Luz",
         "username": "joaopedro17",
         "avatar_url": "https://github.com/joaopedro17.png"
       },
       "url": "https://github.com/joaopedro17/selenium4noobs"
+    },
+    {
+      "name": "Appium4noobs",
+      "tags": ["Testes", "Automação", "Mobile"],
+      "image": "https://cdn.jsdelivr.net/gh/devicons/devicon/icons/appium/appium-original.svg",
+      "description": "Aprenda a automatizar testes em aplicações mobile nativas, híbridas e web com o Appium.",
+      "category": "Frameworks de Automação",
+      "author": {
+        "name": "João Pedro Luz",
+        "username": "joaopedro17",
+        "avatar_url": "https://github.com/joaopedro17.png"
+      },
+      "url": "https://github.com/joaopedro17/appium4noobs"
+    },
+    {
+      "name": "Cypress4noobs",
+      "tags": ["Testes", "Automação", "E2E"],
+      "image": "https://cdn.jsdelivr.net/gh/devicons/devicon/icons/cypressio/cypressio-original.svg",
+      "description": "Aprenda a criar testes end-to-end modernos e confiáveis com o Cypress.",
+      "category": "Frameworks de Automação",
+      "author": {
+        "name": "João Pedro Luz",
+        "username": "joaopedro17",
+        "avatar_url": "https://github.com/joaopedro17.png"
+      },
+      "url": "https://github.com/joaopedro17/cypress4noobs"
+    },
+    {
+      "name": "Playwright4noobs",
+      "tags": ["Testes", "Automação", "E2E"],
+      "image": "https://cdn.jsdelivr.net/gh/devicons/devicon/icons/playwright/playwright-original.svg",
+      "description": "Aprenda a automatizar testes web com o Playwright, suportando múltiplos navegadores.",
+      "category": "Frameworks de Automação",
+      "author": {
+        "name": "João Pedro Luz",
+        "username": "joaopedro17",
+        "avatar_url": "https://github.com/joaopedro17.png"
+      },
+      "url": "https://github.com/joaopedro17/playwright4noobs"
+    },
+    {
+      "name": "Maestro4noobs",
+      "tags": ["Testes", "Automação", "Mobile"],
+      "description": "Aprenda a criar testes de UI mobile de forma simples e eficiente com o Maestro.",
+      "category": "Frameworks de Automação",
+      "author": {
+        "name": "João Pedro Luz",
+        "username": "joaopedro17",
+        "avatar_url": "https://github.com/joaopedro17.png"
+      },
+      "url": "https://github.com/joaopedro17/maestro4noobs"
+    },
+    {
+      "name": "RestAssured4noobs",
+      "tags": ["Testes", "Automação", "API", "Java"],
+      "description": "Aprenda a testar e validar APIs REST em Java utilizando o Rest Assured.",
+      "category": "Frameworks de Automação",
+      "author": {
+        "name": "João Pedro Luz",
+        "username": "joaopedro17",
+        "avatar_url": "https://github.com/joaopedro17.png"
+      },
+      "url": "https://github.com/joaopedro17/restassured4noobs"
     }
   ],
   "socials": {

--- a/README.MD
+++ b/README.MD
@@ -77,10 +77,20 @@ O intuito deste repositório é mostrar projetos desenvolvidos para facilitar o 
 | WM | Vire um mestre do Linux usando Window Manager. Você irá maximizar sua produtividade e se tornar um expert no mundo Linux. | [Geraldo](https://github.com/ahnert37) | [Clique aqui ➡️](https://github.com/ahnert37/wm4noobs) |
 | WSL2 | Utilize Linux e Windows sem precisar de Dual Boot com o Windows Subsystem for Linux | [Rafael Salandin](https://github.com/Salandin) | [Clique aqui ➡️](https://github.com/Salandin/wsl4noobs) |
 | Obsidian | App que oferece recursos avançados de organização e conexão de notas utilizando markdown para ajudá-lo a gerenciar seu conhecimento.  | [Gabi Lima](https://github.com/gabicsl) | [Clique aqui ➡️](https://github.com/gabicsl/obsidian4noobs) |
-| Selenium | Aprenda a usar o Selenium para automação de testes web. | [João Pedro Luz](https://github.com/joaopedro17) | [Clique aqui ➡️](https://github.com/joaopedro17/selenium4noobs) |
 <!---| Clean Code | Aprenda a escrever códigos de forma simplificada e limpa. | [Allan Pires](https://github.com/allan-pires) | <img alt="Badge em breve" src="https://img.shields.io/badge/-EM%20BREVE-red"> |
 | Design Patterns | Aprenda padrões de código para resolução de problemas comuns da forma correta. | [Alexander Santos](https://github.com/ronkiro) | <img alt="Badge em breve" src="https://img.shields.io/badge/-EM%20BREVE-red"> |
 | Docker | Aprenda a subir containers de forma simples. | [Thiago Rezende](https://github.com/thiago-rezende) | <img alt="Badge em breve" src="https://img.shields.io/badge/-EM%20BREVE-red"> |-->
+
+### 🧪 Frameworks de Automação
+
+| Nome | Descrição | Contribuidores | Link |
+| ------ | ------ | ------ | ------ |
+| Selenium | Aprenda a usar o Selenium para automação de testes web. | [João Pedro Luz](https://github.com/joaopedro17) | [Clique aqui ➡️](https://github.com/joaopedro17/selenium4noobs) |
+| Appium | Aprenda a automatizar testes em aplicações mobile nativas, híbridas e web com o Appium. | [João Pedro Luz](https://github.com/joaopedro17) | [Clique aqui ➡️](https://github.com/joaopedro17/appium4noobs) |
+| Cypress | Aprenda a criar testes end-to-end modernos e confiáveis com o Cypress. | [João Pedro Luz](https://github.com/joaopedro17) | [Clique aqui ➡️](https://github.com/joaopedro17/cypress4noobs) |
+| Playwright | Aprenda a automatizar testes web com o Playwright, suportando múltiplos navegadores. | [João Pedro Luz](https://github.com/joaopedro17) | [Clique aqui ➡️](https://github.com/joaopedro17/playwright4noobs) |
+| Maestro | Aprenda a criar testes de UI mobile de forma simples e eficiente com o Maestro. | [João Pedro Luz](https://github.com/joaopedro17) | [Clique aqui ➡️](https://github.com/joaopedro17/maestro4noobs) |
+| Rest Assured | Aprenda a testar e validar APIs REST em Java utilizando o Rest Assured. | [João Pedro Luz](https://github.com/joaopedro17) | [Clique aqui ➡️](https://github.com/joaopedro17/restassured4noobs) |
 
 
 ### 💻 Sistemas operacionais


### PR DESCRIPTION
## Frameworks de Automação4noobs

##  Descrição

  Adição de uma nova seção 🧪 Frameworks de Automação ao README e ao config.json, reunindo todos os meus 4noobs voltados
   a testes e automação:

  - Selenium4noobs — movido de Ferramentas para a nova seção
  - Appium4noobs — automação de testes mobile (nativo, híbrido e web)
  - Cypress4noobs — testes end-to-end modernos
  - Playwright4noobs — automação web com suporte a múltiplos navegadores
  - Maestro4noobs — testes de UI mobile simples e eficientes
  - RestAssured4noobs — testes e validação de APIs REST em Java

##  Minhas redes sociais

Github: https://github.com/joaopedro17

## Requisitos

O meu 4noobs possui todos os requisitos abaixo:

- [x] O meu 4noobs está finalizado
- [x] O meu 4noobs segue o [seguinte template de roadmap](https://github.com/he4rt/4noobs/blob/master/examples/README.md)
- [x] O meu 4noobs não fere nenhum direito autoral
- [x] Inseri corretamente o meu 4noobs no README.md sem nenhum conflito
- [x] Inseri corretamente o meu 4noobs no arquivo [.github/config.json](https://github.com/he4rt/4noobs/blob/master/.github/config.json)
- [x] Tenho a plena consciência de que o meu 4noobs não será validado se os requisitios acima não estiverem de acordo
