### PR TITLE
ci: add auto-assign workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    open-pull-requests-limit: 10
+    schedule:
+      interval: 'weekly'
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: 'ci'

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,24 @@
+name: Auto assign
+
+on:
+  # zizmor: ignore[dangerous-triggers]
+  pull_request_target:
+    branches: [master]
+    types: [opened, reopened]
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  assign:
+    if: github.repository == 'he4rt/4noobs'
+    name: Author
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: he4rt/.github/actions/auto-assign@3f3ca844aeab9a0c2d63a5f661284425f1123a8b # main


### PR DESCRIPTION
## Summary
- Add auto-assign workflow that assigns PR authors automatically on open/reopen
- Uses shared `he4rt/.github/actions/auto-assign` composite action pinned by SHA
- Standardize `dependabot.yml` with `github-actions` ecosystem monitoring (weekly, 7-day cooldown, `ci` commit prefix)

## Test plan
- [ ] Open a test PR to verify the author is auto-assigned
- [ ] Verify Dependabot picks up github-actions updates on next weekly scan